### PR TITLE
Task/08 balancer/kirillgrachoff

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
     build:
       context: .
       dockerfile: photos/photos.Dockerfile
+      args:
+        JAVA_VERSION: "17.0.9-amzn"
     ports:
       - "8083:8083"
     expose:
@@ -34,6 +36,8 @@ services:
     build:
       context: .
       dockerfile: auth/auth.Dockerfile
+      args:
+        JAVA_VERSION: "17.0.9-amzn"
     ports:
       - "8082:8082"
     expose:
@@ -41,16 +45,50 @@ services:
     depends_on:
       - user_database
 
-  routing:
+  routing-1:
     build:
       context: .
       dockerfile: routing/routing.Dockerfile
+      args:
+        JAVA_VERSION: "17.0.9-amzn"
+    deploy:
+      restart_policy:
+        condition: on-failure
+        delay: 10s
+        max_attempts: 3
     ports:
-      - "8081:8081"
-    expose:
       - "8081"
     depends_on:
       - routing_database
+  routing-2:
+    extends:
+      service: routing-1
+  routing-3:
+    extends:
+      service: routing-1
+
+  routing_balancer:
+    image: nginx
+    deploy:
+      resources:
+        limits:
+          memory: 64M
+        reservations:
+          cpus: '0.25'
+          memory: 20M
+    ports:
+      - "8084:8084"
+    expose:
+      - "8084"
+    volumes:
+      - "./routing/balancer/nginx.conf:/etc/nginx/nginx.conf"
+    depends_on:
+      routing-1:
+        condition: service_started
+      routing-2:
+        condition: service_started
+      routing-3:
+        condition: service_started
 
 volumes:
   user-data:

--- a/routing/balancer/nginx.conf
+++ b/routing/balancer/nginx.conf
@@ -1,0 +1,18 @@
+events {}
+
+http {
+    upstream routing_group {
+        least_conn;
+        server routing-1:8081;
+        server routing-2:8081;
+        server routing-3:8081;
+    }
+    server {
+        listen 8084;
+
+        location /routes {
+            proxy_pass http://routing_group;
+            proxy_connect_timeout 1s;
+        }
+    }
+}


### PR DESCRIPTION
nginx точно работает. Вот логи:
```
routing_balancer-1  | 2023/12/17 20:14:49 [error] 28#28: *1 upstream timed out (110: Connection timed out) while connecting to upstream, client: 172.18.0.1, server: , request: "GET /routes HTTP/1.1", upstream: "http://172.18.0.7:8081/routes", host: "localhost:8084"
routing_balancer-1  | 2023/12/17 20:14:50 [error] 28#28: *1 upstream timed out (110: Connection timed out) while connecting to upstream, client: 172.18.0.1, server: , request: "GET /routes HTTP/1.1", upstream: "http://172.18.0.8:8081/routes", host: "localhost:8084"
routing_balancer-1  | 2023/12/17 20:14:51 [error] 28#28: *1 upstream timed out (110: Connection timed out) while connecting to upstream, client: 172.18.0.1, server: , request: "GET /routes HTTP/1.1", upstream: "http://172.18.0.6:8081/routes", host: "localhost:8084"
routing_balancer-1  | 172.18.0.1 - - [17/Dec/2023:20:14:51 +0000] "GET /routes HTTP/1.1" 504 569 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.5993.2477 YaBrowser/23.11.0.2477 Yowser/2.5 Safari/537.36"
routing_balancer-1  | 2023/12/17 20:14:51 [error] 28#28: *1 open() "/etc/nginx/html/favicon.ico" failed (2: No such file or directory), client: 172.18.0.1, server: , request: "GET /favicon.ico HTTP/1.1", host: "localhost:8084", referrer: "http://localhost:8084/routes"
routing_balancer-1  | 172.18.0.1 - - [17/Dec/2023:20:14:51 +0000] "GET /favicon.ico HTTP/1.1" 404 555 "http://localhost:8084/routes" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.5993.2477 YaBrowser/23.11.0.2477 Yowser/2.5 Safari/537.36"
```